### PR TITLE
feat: add the remainder of valid fields to Launchd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ io =["serde", "plist"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
 plist = { version = "1", optional = true }
-cron = { version = "0.9", optional = true }
+cron = { version = "0.12", optional = true }
 thiserror = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::ops::RangeInclusive;
 use thiserror::Error;
 
@@ -19,4 +20,13 @@ pub enum Error {
     #[cfg(feature = "io")]
     #[error(transparent)]
     Write(plist::Error),
+}
+
+// Errors for deserializing Strings into enums that have invalid values.
+pub struct EnumDeserializationFromStrError;
+
+impl fmt::Display for EnumDeserializationFromStrError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("EnumDeserializationFromStrError")
+    }
 }

--- a/src/keep_alive.rs
+++ b/src/keep_alive.rs
@@ -1,0 +1,66 @@
+// See the KeepAlive section in https://www.manpagez.com/man/5/launchd.plist/
+//
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum KeepAliveType {
+    Enabled(bool),
+    Options(KeepAliveOptions),
+}
+
+impl From<bool> for KeepAliveType {
+    fn from(value: bool) -> Self {
+        KeepAliveType::Enabled(value)
+    }
+}
+
+impl From<KeepAliveOptions> for KeepAliveType {
+    fn from(value: KeepAliveOptions) -> Self {
+        KeepAliveType::Options(value)
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "io", serde(rename_all = "PascalCase"))]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct KeepAliveOptions {
+    successful_exit: Option<bool>,
+    network_state: Option<bool>,
+    path_state: Option<HashMap<String, bool>>,
+    other_job_enabled: Option<HashMap<String, bool>>,
+}
+
+impl KeepAliveOptions {
+    pub fn new() -> Self {
+        Self {
+            successful_exit: None,
+            network_state: None,
+            path_state: None,
+            other_job_enabled: None,
+        }
+    }
+
+    pub fn with_successful_exit(mut self, value: bool) -> Self {
+        self.successful_exit = Some(value);
+        self
+    }
+
+    pub fn with_network_state(mut self, value: bool) -> Self {
+        self.network_state = Some(value);
+        self
+    }
+
+    pub fn with_path_state(mut self, value: HashMap<String, bool>) -> Self {
+        self.path_state = Some(value);
+        self
+    }
+
+    pub fn with_other_job_enabled(mut self, value: HashMap<String, bool>) -> Self {
+        self.other_job_enabled = Some(value);
+        self
+    }
+}

--- a/src/keep_alive.rs
+++ b/src/keep_alive.rs
@@ -36,9 +36,7 @@ pub struct KeepAliveOptions {
 
 impl KeepAliveOptions {
     pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
+        Self::default()
     }
 
     pub fn with_successful_exit(mut self, value: bool) -> Self {

--- a/src/keep_alive.rs
+++ b/src/keep_alive.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeepAliveType {
     Enabled(bool),
     Options(KeepAliveOptions),
@@ -37,10 +37,7 @@ pub struct KeepAliveOptions {
 impl KeepAliveOptions {
     pub fn new() -> Self {
         Self {
-            successful_exit: None,
-            network_state: None,
-            path_state: None,
-            other_job_enabled: None,
+            ..Default::default()
         }
     }
 

--- a/src/mach_services.rs
+++ b/src/mach_services.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MachServiceEntry {
     Boolean(bool),
     Map(MachServiceOptions),
@@ -22,8 +22,7 @@ pub struct MachServiceOptions {
 impl MachServiceOptions {
     pub fn new() -> Self {
         Self {
-            reset_at_close: None,
-            hide_until_check_in: None,
+            ..Default::default()
         }
     }
 

--- a/src/mach_services.rs
+++ b/src/mach_services.rs
@@ -21,9 +21,7 @@ pub struct MachServiceOptions {
 
 impl MachServiceOptions {
     pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
+        Self::default()
     }
 
     pub fn with_reset_at_close(mut self, value: bool) -> Self {

--- a/src/mach_services.rs
+++ b/src/mach_services.rs
@@ -1,0 +1,59 @@
+// See the MachServices section in https://www.manpagez.com/man/5/launchd.plist/
+//
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum MachServiceEntry {
+    Boolean(bool),
+    Map(MachServiceOptions),
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "io", serde(rename_all = "PascalCase"))]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MachServiceOptions {
+    reset_at_close: Option<bool>,
+    hide_until_check_in: Option<bool>,
+}
+
+impl MachServiceOptions {
+    pub fn new() -> Self {
+        Self {
+            reset_at_close: None,
+            hide_until_check_in: None,
+        }
+    }
+
+    pub fn with_reset_at_close(mut self, value: bool) -> Self {
+        self.reset_at_close = Some(value);
+        self
+    }
+
+    pub fn reset_at_close(self) -> Self {
+        self.with_reset_at_close(true)
+    }
+
+    pub fn with_hide_until_check_in(mut self, value: bool) -> Self {
+        self.hide_until_check_in = Some(value);
+        self
+    }
+
+    pub fn hide_until_check_in(self) -> Self {
+        self.with_hide_until_check_in(true)
+    }
+}
+
+impl From<MachServiceOptions> for MachServiceEntry {
+    fn from(options: MachServiceOptions) -> Self {
+        MachServiceEntry::Map(options)
+    }
+}
+
+impl From<bool> for MachServiceEntry {
+    fn from(value: bool) -> Self {
+        MachServiceEntry::Boolean(value)
+    }
+}

--- a/src/process_type.rs
+++ b/src/process_type.rs
@@ -1,0 +1,29 @@
+use crate::error::EnumDeserializationFromStrError;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+// TryFrom<String> is needed due to https://github.com/serde-rs/serde/issues/1183
+// While still allowing the caller to use .with_process_type(ProcessType::Background)
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "String"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessType {
+    Background,
+    Standard,
+    Adaptive,
+    Interactive,
+}
+
+impl TryFrom<String> for ProcessType {
+    type Error = EnumDeserializationFromStrError;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match s.as_str() {
+            "Background" => Ok(ProcessType::Background),
+            "Standard" => Ok(ProcessType::Standard),
+            "Adaptive" => Ok(ProcessType::Adaptive),
+            "Interactive" => Ok(ProcessType::Interactive),
+            _ => Err(EnumDeserializationFromStrError),
+        }
+    }
+}

--- a/src/resource_limits.rs
+++ b/src/resource_limits.rs
@@ -1,0 +1,81 @@
+// See the HardResourceLimits / SoftResourceLimits section of https://www.manpagez.com/man/5/launchd.plist/
+//
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "io", serde(rename_all = "PascalCase"))]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ResourceLimits {
+    core: Option<u64>,
+    #[serde(rename = "CPU")]
+    cpu: Option<u64>,
+    data: Option<u64>,
+    file_size: Option<u64>,
+    memory_lock: Option<u64>,
+    number_of_files: Option<u64>,
+    number_of_processes: Option<u64>,
+    resident_set_size: Option<u64>,
+    stack: Option<u64>,
+}
+
+impl ResourceLimits {
+    pub fn new() -> Self {
+        Self {
+            core: None,
+            cpu: None,
+            data: None,
+            file_size: None,
+            memory_lock: None,
+            number_of_files: None,
+            number_of_processes: None,
+            resident_set_size: None,
+            stack: None,
+        }
+    }
+
+    pub fn with_core(mut self, value: u64) -> Self {
+        self.core = Some(value);
+        self
+    }
+
+    pub fn with_cpu(mut self, value: u64) -> Self {
+        self.cpu = Some(value);
+        self
+    }
+
+    pub fn with_data(mut self, value: u64) -> Self {
+        self.data = Some(value);
+        self
+    }
+
+    pub fn with_file_size(mut self, value: u64) -> Self {
+        self.file_size = Some(value);
+        self
+    }
+
+    pub fn with_memory_lock(mut self, value: u64) -> Self {
+        self.memory_lock = Some(value);
+        self
+    }
+
+    pub fn with_number_of_files(mut self, value: u64) -> Self {
+        self.number_of_files = Some(value);
+        self
+    }
+
+    pub fn with_number_of_processes(mut self, value: u64) -> Self {
+        self.number_of_processes = Some(value);
+        self
+    }
+
+    pub fn with_resident_set_size(mut self, value: u64) -> Self {
+        self.resident_set_size = Some(value);
+        self
+    }
+
+    pub fn with_stack(mut self, value: u64) -> Self {
+        self.stack = Some(value);
+        self
+    }
+}

--- a/src/resource_limits.rs
+++ b/src/resource_limits.rs
@@ -21,9 +21,7 @@ pub struct ResourceLimits {
 
 impl ResourceLimits {
     pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
+        Self::default()
     }
 
     pub fn with_core(mut self, value: u64) -> Self {

--- a/src/resource_limits.rs
+++ b/src/resource_limits.rs
@@ -22,15 +22,7 @@ pub struct ResourceLimits {
 impl ResourceLimits {
     pub fn new() -> Self {
         Self {
-            core: None,
-            cpu: None,
-            data: None,
-            file_size: None,
-            memory_lock: None,
-            number_of_files: None,
-            number_of_processes: None,
-            resident_set_size: None,
-            stack: None,
+            ..Default::default()
         }
     }
 

--- a/src/sockets.rs
+++ b/src/sockets.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Sockets {
     Dictionary(HashMap<String, SocketOptions>),
     Array(Vec<HashMap<String, SocketOptions>>),
@@ -45,6 +45,7 @@ impl Socket {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "io", serde(rename_all = "PascalCase"))]
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SocketOptions {
@@ -88,17 +89,7 @@ pub enum SocketFamily {
 impl SocketOptions {
     pub fn new() -> Self {
         Self {
-            sock_type: None,
-            sock_passive: None,
-            sock_node_name: None,
-            sock_service_name: None,
-            sock_family: None,
-            sock_protocol: None,
-            sock_path_name: None,
-            secure_socket_with_key: None,
-            sock_path_mode: None,
-            bonjour: None,
-            multicast_group: None,
+            ..Default::default()
         }
     }
 

--- a/src/sockets.rs
+++ b/src/sockets.rs
@@ -58,7 +58,7 @@ pub struct SocketOptions {
     sock_path_name: Option<String>,
     secure_socket_with_key: Option<String>,
     sock_path_mode: Option<i128>,
-    bonjour: Option<BonjourTypes>,
+    bonjour: Option<BonjourType>,
     multicast_group: Option<String>,
 }
 
@@ -88,9 +88,7 @@ pub enum SocketFamily {
 
 impl SocketOptions {
     pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
+        Self::default()
     }
 
     pub fn with_type(mut self, value: SocketType) -> Self {
@@ -147,7 +145,7 @@ impl SocketOptions {
         self
     }
 
-    pub fn with_bonjour(mut self, value: BonjourTypes) -> Self {
+    pub fn with_bonjour(mut self, value: BonjourType) -> Self {
         self.bonjour = Some(value);
         self
     }
@@ -161,26 +159,26 @@ impl SocketOptions {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BonjourTypes {
+pub enum BonjourType {
     Boolean(bool),
     String(String),
     Array(Vec<String>),
 }
 
-impl From<bool> for BonjourTypes {
+impl From<bool> for BonjourType {
     fn from(value: bool) -> Self {
-        BonjourTypes::Boolean(value)
+        BonjourType::Boolean(value)
     }
 }
 
-impl From<String> for BonjourTypes {
+impl From<String> for BonjourType {
     fn from(value: String) -> Self {
-        BonjourTypes::String(value)
+        BonjourType::String(value)
     }
 }
 
-impl From<Vec<String>> for BonjourTypes {
+impl From<Vec<String>> for BonjourType {
     fn from(value: Vec<String>) -> Self {
-        BonjourTypes::Array(value)
+        BonjourType::Array(value)
     }
 }

--- a/src/sockets.rs
+++ b/src/sockets.rs
@@ -1,0 +1,195 @@
+// See the Sockets section in https://www.manpagez.com/man/5/launchd.plist/
+//
+
+use crate::error::Error;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::path::Path;
+
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum Sockets {
+    Dictionary(HashMap<String, SocketOptions>),
+    Array(Vec<HashMap<String, SocketOptions>>),
+}
+
+impl From<Socket> for Sockets {
+    fn from(socket: Socket) -> Self {
+        Sockets::Dictionary(socket.values)
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq)]
+pub struct Socket {
+    values: HashMap<String, SocketOptions>,
+}
+
+impl Deref for Socket {
+    type Target = HashMap<String, SocketOptions>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.values
+    }
+}
+
+impl Socket {
+    pub fn new<S: AsRef<str>>(name: S, options: SocketOptions) -> Self {
+        Self {
+            values: HashMap::from([(name.as_ref().to_string(), options)]),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "io", serde(rename_all = "PascalCase"))]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SocketOptions {
+    sock_type: Option<SocketType>,
+    sock_passive: Option<bool>,
+    sock_node_name: Option<String>,
+    sock_service_name: Option<String>,
+    sock_family: Option<SocketFamily>,
+    sock_protocol: Option<SocketProtocol>,
+    sock_path_name: Option<String>,
+    secure_socket_with_key: Option<String>,
+    sock_path_mode: Option<i128>,
+    bonjour: Option<BonjourTypes>,
+    multicast_group: Option<String>,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SocketType {
+    Dgram,
+    Stream,
+    Seqpacket,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "UPPERCASE"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SocketProtocol {
+    Tcp,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SocketFamily {
+    IPv4,
+    IPv6,
+    Unix,
+}
+
+impl SocketOptions {
+    pub fn new() -> Self {
+        Self {
+            sock_type: None,
+            sock_passive: None,
+            sock_node_name: None,
+            sock_service_name: None,
+            sock_family: None,
+            sock_protocol: None,
+            sock_path_name: None,
+            secure_socket_with_key: None,
+            sock_path_mode: None,
+            bonjour: None,
+            multicast_group: None,
+        }
+    }
+
+    pub fn with_type(mut self, value: SocketType) -> Self {
+        self.sock_type = Some(value);
+        self
+    }
+
+    pub fn with_passive(mut self, value: bool) -> Self {
+        self.sock_passive = Some(value);
+        self
+    }
+
+    pub fn passive(self) -> Self {
+        self.with_passive(true)
+    }
+
+    pub fn with_node_name<S: AsRef<str>>(mut self, value: S) -> Self {
+        self.sock_node_name = Some(value.as_ref().to_string());
+        self
+    }
+
+    pub fn with_service_name<S: AsRef<str>>(mut self, value: S) -> Self {
+        self.sock_service_name = Some(value.as_ref().to_string());
+        self
+    }
+
+    pub fn with_family(mut self, value: SocketFamily) -> Self {
+        self.sock_family = Some(value);
+        self
+    }
+
+    pub fn with_protocol(mut self, value: SocketProtocol) -> Self {
+        self.sock_protocol = Some(value);
+        self
+    }
+
+    pub fn with_path_name<P: AsRef<Path>>(mut self, name: P) -> Result<Self, Error> {
+        let pathstr = name
+            .as_ref()
+            .to_str()
+            .ok_or(Error::PathConversion)?
+            .to_owned();
+        self.sock_path_name = Some(pathstr);
+        Ok(self)
+    }
+
+    pub fn with_secure_socket_key<S: AsRef<str>>(mut self, value: S) -> Self {
+        self.secure_socket_with_key = Some(value.as_ref().to_string());
+        self
+    }
+
+    pub fn with_path_mode(mut self, value: i128) -> Self {
+        self.sock_path_mode = Some(value);
+        self
+    }
+
+    pub fn with_bonjour(mut self, value: BonjourTypes) -> Self {
+        self.bonjour = Some(value);
+        self
+    }
+
+    pub fn with_multicast_group<S: AsRef<str>>(mut self, value: S) -> Self {
+        self.multicast_group = Some(value.as_ref().to_string());
+        self
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BonjourTypes {
+    Boolean(bool),
+    String(String),
+    Array(Vec<String>),
+}
+
+impl From<bool> for BonjourTypes {
+    fn from(value: bool) -> Self {
+        BonjourTypes::Boolean(value)
+    }
+}
+
+impl From<String> for BonjourTypes {
+    fn from(value: String) -> Self {
+        BonjourTypes::String(value)
+    }
+}
+
+impl From<Vec<String>> for BonjourTypes {
+    fn from(value: Vec<String>) -> Self {
+        BonjourTypes::Array(value)
+    }
+}

--- a/tests/resources/launchevents-1.plist
+++ b/tests/resources/launchevents-1.plist
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnableTransactions</key>
+	<true/>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>NSRunningFromLaunchd</key>
+		<string>1</string>
+		<key>AB_PLUGIN_PATH</key>
+		<string>/tmp</string>
+	</dict>
+	<key>Label</key>
+	<string>com.apple.telephonyutilities.callservicesd</string>
+	<key>MachServices</key>
+	<dict>
+		<key>com.apple.telephonyutilities.callservicesdaemon</key>
+		<true/>
+		<key>com.apple.telephonyutilities.callservicesdaemon.accountscontroller</key>
+		<true/>
+		<key>com.apple.private.alloy.phonecontinuity-idswake</key>
+		<true/>
+	</dict>
+	<key>LaunchEvents</key>
+	<dict>
+		<key>com.apple.distnoted.matching</key>
+		<dict>
+			<key>com.apple.callhistory.save.distributed.notification</key>
+			<dict>
+				<key>Name</key>
+				<string>com.apple.callhistory.save.distributed.notification</string>
+			</dict>
+		</dict>
+		<key>com.apple.notifyd.matching</key>
+		<dict>
+			<key>com.apple.phone.idslaunchnotification</key>
+			<dict>
+				<key>Notification</key>
+				<string>com.apple.phone.idslaunchnotification</string>
+			</dict>
+			<key>com.apple.telephonyutilities.callservicesd.fakeincomingmessage</key>
+			<dict>
+				<key>Notification</key>
+				<string>com.apple.telephonyutilities.callservicesd.fakeincomingmessage</string>
+			</dict>
+			<key>com.apple.telephonyutilities.callservicesd.fakeoutgoingmessage</key>
+			<dict>
+				<key>Notification</key>
+				<string>com.apple.telephonyutilities.callservicesd.fakeoutgoingmessage</string>
+			</dict>
+			<key>com.apple.telephonyutilities.callservicesd.kFaceTimeChangedNotification</key>
+			<dict>
+				<key>Notification</key>
+				<string>kFaceTimeChangedNotification</string>
+			</dict>
+		</dict>
+	</dict>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/bin/sandbox-exec</string>
+		<string>-p</string>
+		<string>(version 1)(allow default)(deny file-read* (regex #"^/System/Library/Address Book Plug-Ins/POI*"))</string>
+		<string>/System/Library/PrivateFrameworks/TelephonyUtilities.framework/callservicesd</string>
+   </array>
+	<key>EnablePressuredExit</key>
+	<true/>
+	<key>ProcessType</key>
+	<string>Adaptive</string>
+</dict>
+</plist>

--- a/tests/resources/launchevents-2.plist
+++ b/tests/resources/launchevents-2.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.podtynnyi.com.yubikeylockd</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/bin/yubikeylockd</string>
+    </array>
+    <key>LaunchEvents</key>
+    <dict>
+      <key>com.apple.iokit.matching</key>
+      <dict>
+        <key>com.apple.device-attach</key>
+        <dict>
+            <key>idProduct</key>
+            <string>*</string>
+            <key>idVendor</key>
+            <integer>4176</integer>
+            <key>IOProviderClass</key>
+            <string>IOUSBDevice</string>
+            <key>IOMatchLaunchStream</key>
+            <true/>
+        </dict>
+      </dict>
+    </dict>
+  </dict>
+</plist>

--- a/tests/resources/machservices-1.plist
+++ b/tests/resources/machservices-1.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.apple.AssistiveControl</string>
+	<key>MachServices</key>
+	<dict>
+		<key>com.apple.private.alloy.accessibility.switchcontrol-idswake</key>
+		<true/>
+		<key>com.apple.AssistiveControl.startup</key>
+		<dict>
+			<key>ResetAtClose</key>
+			<true/>
+		</dict>
+		<key>com.apple.AssistiveControl.running</key>
+		<dict>
+			<key>HideUntilCheckIn</key>
+			<true/>
+			<key>ResetAtClose</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/System/Library/Input Methods/Assistive Control.app/Contents/MacOS/Assistive Control</string>
+		<string>launchd</string>
+		<string>-s</string>
+	</array>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>EnableTransactions</key>
+	<true/>
+	<key>ThrottleInterval</key>
+	<integer>1</integer>
+	<key>LimitLoadToSessionType</key>
+	<array>
+		<string>Aqua</string>
+		<string>LoginWindow</string>
+	</array>
+	<key>ProcessType</key>
+	<string>Interactive</string>
+</dict>
+</plist>


### PR DESCRIPTION
More complex code for Sockets, KeepAlive, MachServices & ResourceLimits.

Let me know if you're ok with this approach and I can add some tests.

Here's a driver program I've been using to test:

```rust
use launchd::mach_services::{MachServiceEntry, MachServiceOptions};
use launchd::sockets::SocketFamily;
use launchd::{
    BonjourTypes, KeepAliveOptions, KeepAliveType, Launchd, ProcessType, ResourceLimits, Socket,
    SocketOptions, Sockets,
};
use std::collections::HashMap;
use std::path::Path;

fn main() {
    let keep_alive = KeepAliveOptions::new()
        .with_successful_exit(true)
        .with_network_state(true);

    let socket_options = SocketOptions::new()
        .with_node_name("127.0.0.1")
        .with_family(SocketFamily::Unix)
        .with_bonjour(BonjourTypes::from(vec![
            String::from("foo"),
            String::from("bar"),
        ]));

    let socket = Socket::new("Listener", socket_options);

    let mut mach_services = HashMap::new();

    mach_services.insert("com.apple.test".to_string(), MachServiceEntry::from(true));
    mach_services.insert(
        "org.rust-lang".to_string(),
        MachServiceEntry::from(MachServiceOptions::new().reset_at_close()),
    );

    let launchd = Launchd::new("LABEL", Path::new("./foo"))
        .unwrap()
        .with_user_name("Henk")
        .with_program_arguments(vec!["Hello".to_string(), "World!".to_string()])
        .disabled()
        .with_keep_alive(KeepAliveType::from(keep_alive))
        .with_process_type(ProcessType::Background)
        .with_socket(Sockets::from(socket))
        .with_soft_resource_limits(
            ResourceLimits::new()
                .with_core(1)
                .with_data(2)
                .with_file_size(3)
                .with_stack(5)
                .with_cpu(6),
        )
        .with_mach_services(mach_services)
        .with_inetd_compatibility(true);

    launchd.to_file_xml(Path::new("./test.plist")).unwrap();
}
```